### PR TITLE
Generate OpenAPI documentation for all APIs

### DIFF
--- a/api-docs/README.md
+++ b/api-docs/README.md
@@ -1,0 +1,237 @@
+# Hibernate ORM API Documentation
+
+This directory contains comprehensive OpenAPI documentation for all Hibernate ORM APIs. While Hibernate ORM is a Java Object-Relational Mapping framework (not a REST service), these OpenAPI specifications document the Java APIs in a structured, accessible format for developers.
+
+## 📚 API Documentation Files
+
+### 1. Core Session Management API
+**File:** `hibernate-core-session-api.yaml`
+
+Documents the fundamental Hibernate APIs for:
+- **SessionFactory**: Factory for creating and managing sessions
+- **Session**: Main runtime interface for persistence operations  
+- **Transaction**: Transaction management and lifecycle
+- **Entity Operations**: CRUD operations (Create, Read, Update, Delete)
+
+**Key APIs Covered:**
+- Session lifecycle management (open, close, flush, clear)
+- Entity persistence operations (persist, merge, find, remove, refresh)
+- Transaction management (begin, commit, rollback)
+- SessionFactory creation and configuration
+
+---
+
+### 2. Query API
+**File:** `hibernate-query-api.yaml`
+
+Documents Hibernate's comprehensive query capabilities:
+- **HQL Queries**: Hibernate Query Language operations
+- **Criteria Queries**: Type-safe programmatic queries
+- **Native Queries**: Direct SQL query support
+- **Query Execution**: Various result retrieval methods
+- **Parameter Binding**: Named and positional parameter handling
+
+**Key APIs Covered:**
+- Query creation (HQL, Criteria, Native SQL, Named queries)
+- Parameter binding and configuration
+- Result retrieval (list, single, unique, stream, scrollable)
+- Query optimization and caching
+
+---
+
+### 3. Schema Management API  
+**File:** `hibernate-schema-api.yaml`
+
+Documents database schema management capabilities:
+- **Schema Manager**: Core schema operations
+- **DDL Generation**: Database schema DDL generation
+- **Schema Validation**: Schema correctness validation
+- **Schema Migration**: Schema evolution and updates
+- **Metadata Extraction**: Database metadata inspection
+
+**Key APIs Covered:**
+- Schema creation, dropping, and migration
+- DDL script generation (CREATE, DROP, UPDATE)
+- Schema validation against mappings
+- Database metadata extraction (tables, columns, indexes, sequences)
+
+---
+
+### 4. Extended Modules API
+**File:** `hibernate-modules-api.yaml`
+
+Documents specialized Hibernate modules:
+- **Envers Auditing**: Entity auditing and revision tracking
+- **Spatial Operations**: GIS and spatial data support
+- **Vector Operations**: Vector embeddings and similarity search
+- **Cache Management**: Second-level cache operations
+- **Statistics**: Runtime metrics and performance monitoring
+
+**Key APIs Covered:**
+- Audit trail management and revision queries
+- Spatial predicates and geometry operations
+- Vector similarity search and distance calculations
+- Cache eviction and statistics
+- Performance metrics and monitoring
+
+---
+
+### 5. Tooling API
+**File:** `hibernate-tooling-api.yaml`
+
+Documents development and build-time tools:
+- **Metamodel Generator**: Static metamodel generation
+- **Build Plugins**: Gradle, Maven, and Ant integrations
+- **Connection Pools**: HikariCP, C3P0, and Agroal configuration
+- **Development Tools**: Debugging and monitoring utilities
+
+**Key APIs Covered:**
+- Annotation processing and metamodel generation
+- Bytecode enhancement and schema generation
+- Connection pool configuration and monitoring
+- SQL logging, JFR events, and Micrometer metrics
+
+---
+
+## 🏗️ Architecture Overview
+
+### Core Components
+```
+SessionFactory (Root)
+├── Session (Persistence Context)
+│   ├── Transaction (Transaction Management)
+│   ├── Query (HQL/Criteria/Native SQL)
+│   └── Entity Operations (CRUD)
+├── Cache (Second-level Caching)
+├── Statistics (Performance Metrics)
+└── SchemaManager (DDL Operations)
+```
+
+### Extended Modules
+```
+Hibernate Modules
+├── Envers (Auditing)
+├── Spatial (GIS Support)
+├── Vector (Embeddings)
+├── JCache (Caching)
+├── Micrometer (Metrics)
+├── JFR (Flight Recorder)
+└── Connection Pools (HikariCP/C3P0/Agroal)
+```
+
+### Development Tools
+```
+Tooling
+├── Metamodel Generator
+├── Build Plugins (Gradle/Maven/Ant)
+├── Bytecode Enhancement
+└── Development Utilities
+```
+
+## 🚀 Getting Started
+
+### Basic Usage Pattern
+1. **Configure SessionFactory** - Set up database connection and mappings
+2. **Open Session** - Create a persistence context
+3. **Begin Transaction** - Start a database transaction
+4. **Perform Operations** - Execute queries and entity operations
+5. **Commit/Rollback** - Complete or abort the transaction
+6. **Close Session** - Release resources
+
+### Example Workflow (Conceptual)
+```
+POST /session-factory                    # Create SessionFactory
+POST /session-factory/{id}/session       # Open Session
+POST /session/{id}/transaction           # Begin Transaction
+POST /session/{id}/entity                # Persist Entity
+GET  /session/{id}/entity/{type}/{id}    # Find Entity
+POST /session/{id}/transaction/commit    # Commit Transaction
+DELETE /session/{id}/close               # Close Session
+```
+
+## 📖 Documentation Format
+
+These OpenAPI specifications use standard HTTP methods and REST patterns to represent Java method calls:
+
+- **GET**: Retrieval operations (find, query, get)
+- **POST**: Creation operations (persist, begin, create)
+- **PUT**: Update operations (merge, update, set)
+- **DELETE**: Removal operations (remove, evict, close)
+
+### Path Structure
+- `/session-factory/{id}` - SessionFactory operations
+- `/session/{id}` - Session-specific operations  
+- `/query/{id}` - Query-specific operations
+- `/cache/{id}` - Cache operations
+- `/schema-manager/{id}` - Schema operations
+
+### Response Codes
+- **200**: Successful operation
+- **201**: Resource created successfully
+- **204**: Operation completed (no content)
+- **400**: Invalid request/parameters
+- **404**: Resource not found
+- **409**: Conflict (e.g., unique constraint violation)
+
+## 🔧 Configuration Examples
+
+### SessionFactory Configuration
+```yaml
+hibernateProperties:
+  hibernate.dialect: "org.hibernate.dialect.PostgreSQLDialect"
+  hibernate.hbm2ddl.auto: "update"
+  hibernate.show_sql: "true"
+  hibernate.format_sql: "true"
+```
+
+### Query Configuration
+```yaml
+maxResults: 10
+firstResult: 0
+timeout: 30000
+cacheable: true
+cacheRegion: "query-cache"
+flushMode: "AUTO"
+```
+
+### Connection Pool Configuration (HikariCP)
+```yaml
+jdbcUrl: "jdbc:postgresql://localhost:5432/mydb"
+username: "user"
+password: "password"
+maximumPoolSize: 20
+connectionTimeout: 30000
+```
+
+## 🎯 Use Cases
+
+### Common Development Scenarios
+1. **Application Development**: Use Session and Query APIs
+2. **Schema Management**: Use Schema Management API
+3. **Performance Monitoring**: Use Statistics and Cache APIs
+4. **Auditing Requirements**: Use Envers Auditing API
+5. **Spatial Applications**: Use Spatial Operations API
+6. **AI/ML Applications**: Use Vector Operations API
+7. **Build Integration**: Use Tooling APIs
+
+### Enterprise Features
+- **Multi-tenancy**: Session-per-tenant isolation
+- **Caching**: Second-level cache for performance
+- **Auditing**: Complete change tracking
+- **Monitoring**: Comprehensive metrics collection
+- **Scalability**: Connection pooling and optimization
+
+## 📚 Additional Resources
+
+- [Hibernate ORM Official Documentation](https://hibernate.org/orm/documentation/)
+- [Hibernate User Guide](https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html)
+- [Jakarta Persistence Specification](https://jakarta.ee/specifications/persistence/)
+- [Hibernate Community](https://hibernate.org/community/)
+
+## 📝 Notes
+
+**Important**: These OpenAPI specifications document Java library APIs, not actual REST endpoints. They serve as comprehensive API documentation in a familiar format. The actual Hibernate APIs are invoked through Java method calls in your application code.
+
+**Version**: Hibernate ORM 7.0.0
+**License**: Apache-2.0
+**Maintained by**: Hibernate Team

--- a/api-docs/hibernate-core-session-api.yaml
+++ b/api-docs/hibernate-core-session-api.yaml
@@ -1,0 +1,454 @@
+openapi: 3.0.3
+info:
+  title: Hibernate Core Session Management API
+  description: |
+    Core Hibernate ORM session management and persistence operations.
+    
+    This documentation represents the main Java APIs for Hibernate Session, SessionFactory, 
+    and Transaction management as OpenAPI specifications for comprehensive API documentation.
+    
+    **Note**: These are Java method APIs, not actual REST endpoints.
+  version: "7.0.0"
+  contact:
+    name: Hibernate Team
+    url: https://hibernate.org
+  license:
+    name: Apache-2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+
+servers:
+  - url: https://api.hibernate.orm/v7
+    description: Hibernate ORM API (conceptual)
+
+tags:
+  - name: SessionFactory
+    description: Factory for creating and managing Hibernate sessions
+  - name: Session
+    description: Main runtime interface for persistence operations
+  - name: Transaction
+    description: Transaction management operations
+  - name: Entity Operations
+    description: CRUD operations on persistent entities
+
+paths:
+  /session-factory:
+    post:
+      tags: [SessionFactory]
+      summary: Create a new session factory
+      description: Creates a SessionFactory instance from configuration
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SessionFactoryConfiguration'
+      responses:
+        '201':
+          description: SessionFactory created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionFactory'
+        '400':
+          description: Invalid configuration
+
+  /session-factory/{factoryId}/session:
+    post:
+      tags: [SessionFactory]
+      summary: Open a new session
+      description: Creates a new Session instance from the SessionFactory
+      parameters:
+        - name: factoryId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '201':
+          description: Session created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Session'
+
+  /session-factory/{factoryId}/current-session:
+    get:
+      tags: [SessionFactory]
+      summary: Get current session
+      description: Retrieves the current contextually-bound session
+      parameters:
+        - name: factoryId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Current session retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Session'
+        '404':
+          description: No current session available
+
+  /session/{sessionId}/entity:
+    post:
+      tags: [Entity Operations]
+      summary: Persist entity
+      description: Make a transient instance persistent
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Entity'
+      responses:
+        '201':
+          description: Entity persisted successfully
+        '400':
+          description: Invalid entity state
+
+    put:
+      tags: [Entity Operations]
+      summary: Merge entity
+      description: Copy state of detached instance to persistent instance
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Entity'
+      responses:
+        '200':
+          description: Entity merged successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Entity'
+
+  /session/{sessionId}/entity/{entityType}/{id}:
+    get:
+      tags: [Entity Operations]
+      summary: Find entity by ID
+      description: Retrieve an entity instance by its identifier
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: entityType
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: lockMode
+          in: query
+          schema:
+            $ref: '#/components/schemas/LockModeType'
+      responses:
+        '200':
+          description: Entity found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Entity'
+        '404':
+          description: Entity not found
+
+    delete:
+      tags: [Entity Operations]
+      summary: Remove entity
+      description: Remove a persistent instance from the datastore
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: entityType
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Entity removed successfully
+        '404':
+          description: Entity not found
+
+  /session/{sessionId}/entity/{entityType}/{id}/refresh:
+    post:
+      tags: [Entity Operations]
+      summary: Refresh entity
+      description: Refresh the state of the instance from the database
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: entityType
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Entity refreshed successfully
+
+  /session/{sessionId}/transaction:
+    post:
+      tags: [Transaction]
+      summary: Begin transaction
+      description: Begin a new transaction associated with the session
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '201':
+          description: Transaction started
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Transaction'
+
+  /session/{sessionId}/transaction/commit:
+    post:
+      tags: [Transaction]
+      summary: Commit transaction
+      description: Commit the current transaction
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Transaction committed successfully
+        '400':
+          description: No active transaction or transaction failed
+
+  /session/{sessionId}/transaction/rollback:
+    post:
+      tags: [Transaction]
+      summary: Rollback transaction
+      description: Roll back the current transaction
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Transaction rolled back successfully
+
+  /session/{sessionId}/flush:
+    post:
+      tags: [Session]
+      summary: Flush session
+      description: Force session to flush (synchronize with database)
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Session flushed successfully
+
+  /session/{sessionId}/clear:
+    post:
+      tags: [Session]
+      summary: Clear session
+      description: Remove all objects from the session cache
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Session cleared successfully
+
+  /session/{sessionId}/close:
+    delete:
+      tags: [Session]
+      summary: Close session
+      description: End the session by releasing the JDBC connection and cleaning up
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Session closed successfully
+
+components:
+  schemas:
+    SessionFactoryConfiguration:
+      type: object
+      properties:
+        hibernateProperties:
+          type: object
+          additionalProperties:
+            type: string
+        mappingResources:
+          type: array
+          items:
+            type: string
+        annotatedClasses:
+          type: array
+          items:
+            type: string
+
+    SessionFactory:
+      type: object
+      properties:
+        factoryId:
+          type: string
+        openSessionsCount:
+          type: integer
+        statistics:
+          $ref: '#/components/schemas/Statistics'
+        cache:
+          $ref: '#/components/schemas/Cache'
+
+    Session:
+      type: object
+      properties:
+        sessionId:
+          type: string
+        isOpen:
+          type: boolean
+        isConnected:
+          type: boolean
+        flushMode:
+          $ref: '#/components/schemas/FlushModeType'
+        cacheMode:
+          $ref: '#/components/schemas/CacheMode'
+        defaultReadOnly:
+          type: boolean
+        transaction:
+          $ref: '#/components/schemas/Transaction'
+
+    Transaction:
+      type: object
+      properties:
+        transactionId:
+          type: string
+        isActive:
+          type: boolean
+        status:
+          $ref: '#/components/schemas/TransactionStatus'
+        rollbackOnly:
+          type: boolean
+
+    Entity:
+      type: object
+      properties:
+        entityType:
+          type: string
+        id:
+          type: object
+        version:
+          type: object
+        properties:
+          type: object
+          additionalProperties: true
+
+    LockModeType:
+      type: string
+      enum:
+        - NONE
+        - READ
+        - WRITE
+        - OPTIMISTIC
+        - OPTIMISTIC_FORCE_INCREMENT
+        - PESSIMISTIC_READ
+        - PESSIMISTIC_WRITE
+        - PESSIMISTIC_FORCE_INCREMENT
+
+    FlushModeType:
+      type: string
+      enum:
+        - AUTO
+        - COMMIT
+        - MANUAL
+
+    CacheMode:
+      type: string
+      enum:
+        - NORMAL
+        - IGNORE
+        - GET
+        - PUT
+        - REFRESH
+
+    TransactionStatus:
+      type: string
+      enum:
+        - ACTIVE
+        - COMMITTED
+        - ROLLED_BACK
+        - MARKED_ROLLBACK
+        - NOT_ACTIVE
+
+    Statistics:
+      type: object
+      properties:
+        sessionOpenCount:
+          type: integer
+        sessionCloseCount:
+          type: integer
+        transactionCount:
+          type: integer
+        queryExecutionCount:
+          type: integer
+
+    Cache:
+      type: object
+      properties:
+        regionNames:
+          type: array
+          items:
+            type: string
+        evictAllRegions:
+          type: boolean

--- a/api-docs/hibernate-modules-api.yaml
+++ b/api-docs/hibernate-modules-api.yaml
@@ -1,0 +1,810 @@
+openapi: 3.0.3
+info:
+  title: Hibernate Modules API
+  description: |
+    Hibernate ORM Extended Modules APIs including Envers (Auditing), Spatial, 
+    Vector, Caching, and other specialized functionality.
+    
+    This documentation represents the Java Module APIs as OpenAPI specifications 
+    for comprehensive documentation. Covers audit trails, spatial data operations, 
+    vector embeddings, caching, and other specialized Hibernate modules.
+    
+    **Note**: These are Java method APIs, not actual REST endpoints.
+  version: "7.0.0"
+  contact:
+    name: Hibernate Team
+    url: https://hibernate.org
+  license:
+    name: Apache-2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+
+servers:
+  - url: https://api.hibernate.orm/v7
+    description: Hibernate ORM Modules API (conceptual)
+
+tags:
+  - name: Envers Auditing
+    description: Entity auditing and revision tracking
+  - name: Spatial Operations
+    description: Spatial and GIS data operations
+  - name: Vector Operations
+    description: Vector embeddings and similarity search
+  - name: Cache Management
+    description: Second-level cache operations
+  - name: Statistics
+    description: Runtime statistics and metrics
+
+paths:
+  # Envers Auditing APIs
+  /session/{sessionId}/audit/revisions/{entityType}/{id}:
+    get:
+      tags: [Envers Auditing]
+      summary: Get entity revisions
+      description: Retrieve all audit revisions for a specific entity
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: entityType
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Entity revisions retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RevisionList'
+
+  /session/{sessionId}/audit/revisions/{revisionNumber}:
+    get:
+      tags: [Envers Auditing]
+      summary: Get revision details
+      description: Retrieve details of a specific revision
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: revisionNumber
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Revision details retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RevisionInfo'
+
+  /session/{sessionId}/audit/entity/{entityType}/{id}/revision/{revisionNumber}:
+    get:
+      tags: [Envers Auditing]
+      summary: Get entity at revision
+      description: Retrieve the state of an entity at a specific revision
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: entityType
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: revisionNumber
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Entity state at revision retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuditedEntity'
+
+  /session/{sessionId}/audit/query:
+    post:
+      tags: [Envers Auditing]
+      summary: Create audit query
+      description: Create a query for audit data
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuditQueryRequest'
+      responses:
+        '201':
+          description: Audit query created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuditQuery'
+
+  # Spatial Operations APIs
+  /session/{sessionId}/spatial/query:
+    post:
+      tags: [Spatial Operations]
+      summary: Create spatial query
+      description: Create a query with spatial predicates
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SpatialQueryRequest'
+      responses:
+        '201':
+          description: Spatial query created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SpatialQuery'
+
+  /session/{sessionId}/spatial/distance:
+    post:
+      tags: [Spatial Operations]
+      summary: Calculate distance
+      description: Calculate distance between two geometries
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DistanceRequest'
+      responses:
+        '200':
+          description: Distance calculated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DistanceResult'
+
+  /session/{sessionId}/spatial/within:
+    post:
+      tags: [Spatial Operations]
+      summary: Find entities within geometry
+      description: Find entities that are within a specified geometry
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WithinQueryRequest'
+      responses:
+        '200':
+          description: Entities within geometry found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SpatialQueryResult'
+
+  # Vector Operations APIs
+  /session/{sessionId}/vector/similarity:
+    post:
+      tags: [Vector Operations]
+      summary: Vector similarity search
+      description: Find entities with similar vector embeddings
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VectorSimilarityRequest'
+      responses:
+        '200':
+          description: Similar vectors found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VectorSimilarityResult'
+
+  /session/{sessionId}/vector/distance:
+    post:
+      tags: [Vector Operations]
+      summary: Calculate vector distance
+      description: Calculate distance between vector embeddings
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VectorDistanceRequest'
+      responses:
+        '200':
+          description: Vector distance calculated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VectorDistanceResult'
+
+  # Cache Management APIs
+  /session-factory/{factoryId}/cache:
+    get:
+      tags: [Cache Management]
+      summary: Get cache manager
+      description: Retrieve the cache manager for the session factory
+      parameters:
+        - name: factoryId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Cache manager retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CacheManager'
+
+  /cache/{managerId}/region/{regionName}:
+    delete:
+      tags: [Cache Management]
+      summary: Evict cache region
+      description: Evict all entries from a cache region
+      parameters:
+        - name: managerId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: regionName
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Cache region evicted
+
+  /cache/{managerId}/entity/{entityType}:
+    delete:
+      tags: [Cache Management]
+      summary: Evict entity cache
+      description: Evict all cached instances of an entity type
+      parameters:
+        - name: managerId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: entityType
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Entity cache evicted
+
+  /cache/{managerId}/entity/{entityType}/{id}:
+    delete:
+      tags: [Cache Management]
+      summary: Evict specific entity
+      description: Evict a specific entity instance from cache
+      parameters:
+        - name: managerId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: entityType
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Entity instance evicted
+
+  /cache/{managerId}/statistics:
+    get:
+      tags: [Cache Management]
+      summary: Get cache statistics
+      description: Retrieve cache performance statistics
+      parameters:
+        - name: managerId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Cache statistics retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CacheStatistics'
+
+  # Statistics APIs
+  /session-factory/{factoryId}/statistics:
+    get:
+      tags: [Statistics]
+      summary: Get session factory statistics
+      description: Retrieve comprehensive runtime statistics
+      parameters:
+        - name: factoryId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Statistics retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HibernateStatistics'
+
+  /statistics/{factoryId}/enable:
+    post:
+      tags: [Statistics]
+      summary: Enable statistics collection
+      description: Enable or disable statistics collection
+      parameters:
+        - name: factoryId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                enabled:
+                  type: boolean
+      responses:
+        '200':
+          description: Statistics collection configured
+
+  /statistics/{factoryId}/clear:
+    post:
+      tags: [Statistics]
+      summary: Clear statistics
+      description: Clear all collected statistics
+      parameters:
+        - name: factoryId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Statistics cleared
+
+components:
+  schemas:
+    # Envers Schemas
+    RevisionList:
+      type: object
+      properties:
+        revisions:
+          type: array
+          items:
+            $ref: '#/components/schemas/RevisionInfo'
+        totalCount:
+          type: integer
+
+    RevisionInfo:
+      type: object
+      properties:
+        revisionNumber:
+          type: integer
+        revisionDate:
+          type: string
+          format: date-time
+        revisionType:
+          $ref: '#/components/schemas/RevisionType'
+        username:
+          type: string
+        properties:
+          type: object
+          additionalProperties: true
+
+    AuditedEntity:
+      type: object
+      properties:
+        entity:
+          type: object
+        revisionInfo:
+          $ref: '#/components/schemas/RevisionInfo'
+        entityType:
+          type: string
+
+    AuditQueryRequest:
+      type: object
+      required:
+        - entityType
+      properties:
+        entityType:
+          type: string
+        criteria:
+          type: object
+        revisionNumberRestriction:
+          type: object
+        revisionDateRestriction:
+          type: object
+
+    AuditQuery:
+      type: object
+      properties:
+        queryId:
+          type: string
+        entityType:
+          type: string
+        resultCount:
+          type: integer
+
+    RevisionType:
+      type: string
+      enum:
+        - ADD
+        - MOD
+        - DEL
+
+    # Spatial Schemas
+    SpatialQueryRequest:
+      type: object
+      required:
+        - entityType
+        - spatialPredicate
+      properties:
+        entityType:
+          type: string
+        spatialPredicate:
+          $ref: '#/components/schemas/SpatialPredicate'
+        geometry:
+          $ref: '#/components/schemas/Geometry'
+        distance:
+          type: number
+        srid:
+          type: integer
+
+    SpatialQuery:
+      type: object
+      properties:
+        queryId:
+          type: string
+        spatialPredicate:
+          $ref: '#/components/schemas/SpatialPredicate'
+
+    SpatialQueryResult:
+      type: object
+      properties:
+        entities:
+          type: array
+          items:
+            type: object
+        distances:
+          type: array
+          items:
+            type: number
+
+    DistanceRequest:
+      type: object
+      required:
+        - geometry1
+        - geometry2
+      properties:
+        geometry1:
+          $ref: '#/components/schemas/Geometry'
+        geometry2:
+          $ref: '#/components/schemas/Geometry'
+
+    DistanceResult:
+      type: object
+      properties:
+        distance:
+          type: number
+        unit:
+          type: string
+
+    WithinQueryRequest:
+      type: object
+      required:
+        - entityType
+        - geometry
+      properties:
+        entityType:
+          type: string
+        geometry:
+          $ref: '#/components/schemas/Geometry'
+        propertyName:
+          type: string
+
+    SpatialPredicate:
+      type: string
+      enum:
+        - WITHIN
+        - CONTAINS
+        - INTERSECTS
+        - TOUCHES
+        - CROSSES
+        - OVERLAPS
+        - DISJOINT
+        - DWITHIN
+
+    Geometry:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: [POINT, LINESTRING, POLYGON, MULTIPOINT, MULTILINESTRING, MULTIPOLYGON]
+        coordinates:
+          type: array
+          items:
+            type: number
+        srid:
+          type: integer
+
+    # Vector Schemas
+    VectorSimilarityRequest:
+      type: object
+      required:
+        - entityType
+        - queryVector
+      properties:
+        entityType:
+          type: string
+        queryVector:
+          type: array
+          items:
+            type: number
+        vectorProperty:
+          type: string
+        similarityFunction:
+          $ref: '#/components/schemas/SimilarityFunction'
+        maxResults:
+          type: integer
+        threshold:
+          type: number
+
+    VectorSimilarityResult:
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/VectorMatch'
+
+    VectorMatch:
+      type: object
+      properties:
+        entity:
+          type: object
+        similarity:
+          type: number
+        distance:
+          type: number
+
+    VectorDistanceRequest:
+      type: object
+      required:
+        - vector1
+        - vector2
+      properties:
+        vector1:
+          type: array
+          items:
+            type: number
+        vector2:
+          type: array
+          items:
+            type: number
+        distanceFunction:
+          $ref: '#/components/schemas/DistanceFunction'
+
+    VectorDistanceResult:
+      type: object
+      properties:
+        distance:
+          type: number
+
+    SimilarityFunction:
+      type: string
+      enum:
+        - COSINE
+        - DOT_PRODUCT
+        - EUCLIDEAN
+        - MANHATTAN
+
+    DistanceFunction:
+      type: string
+      enum:
+        - EUCLIDEAN
+        - MANHATTAN
+        - COSINE
+        - HAMMING
+
+    # Cache Schemas
+    CacheManager:
+      type: object
+      properties:
+        managerId:
+          type: string
+        regions:
+          type: array
+          items:
+            type: string
+        cacheProvider:
+          type: string
+
+    CacheStatistics:
+      type: object
+      properties:
+        hitCount:
+          type: integer
+        missCount:
+          type: integer
+        putCount:
+          type: integer
+        hitRatio:
+          type: number
+        regionStatistics:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/RegionStatistics'
+
+    RegionStatistics:
+      type: object
+      properties:
+        regionName:
+          type: string
+        hitCount:
+          type: integer
+        missCount:
+          type: integer
+        putCount:
+          type: integer
+        elementCountInMemory:
+          type: integer
+        elementCountOnDisk:
+          type: integer
+        sizeInMemory:
+          type: integer
+
+    # Statistics Schemas
+    HibernateStatistics:
+      type: object
+      properties:
+        sessionOpenCount:
+          type: integer
+        sessionCloseCount:
+          type: integer
+        transactionCount:
+          type: integer
+        successfulTransactionCount:
+          type: integer
+        flushCount:
+          type: integer
+        connectCount:
+          type: integer
+        preparedStatementCount:
+          type: integer
+        closeStatementCount:
+          type: integer
+        queryExecutionCount:
+          type: integer
+        queryExecutionMaxTime:
+          type: integer
+        queryExecutionMaxTimeQueryString:
+          type: string
+        queryCacheHitCount:
+          type: integer
+        queryCacheMissCount:
+          type: integer
+        queryCachePutCount:
+          type: integer
+        naturalIdQueryExecutionCount:
+          type: integer
+        naturalIdQueryExecutionMaxTime:
+          type: integer
+        naturalIdCacheHitCount:
+          type: integer
+        naturalIdCacheMissCount:
+          type: integer
+        naturalIdCachePutCount:
+          type: integer
+        updateTimestampsCacheHitCount:
+          type: integer
+        updateTimestampsCacheMissCount:
+          type: integer
+        updateTimestampsCachePutCount:
+          type: integer
+        entityLoadCount:
+          type: integer
+        entityUpdateCount:
+          type: integer
+        entityInsertCount:
+          type: integer
+        entityDeleteCount:
+          type: integer
+        entityFetchCount:
+          type: integer
+        collectionLoadCount:
+          type: integer
+        collectionUpdateCount:
+          type: integer
+        collectionRemoveCount:
+          type: integer
+        collectionRecreateCount:
+          type: integer
+        collectionFetchCount:
+          type: integer
+        secondLevelCacheHitCount:
+          type: integer
+        secondLevelCacheMissCount:
+          type: integer
+        secondLevelCachePutCount:
+          type: integer
+        statisticsEnabled:
+          type: boolean
+        startTime:
+          type: string
+          format: date-time

--- a/api-docs/hibernate-query-api.yaml
+++ b/api-docs/hibernate-query-api.yaml
@@ -1,0 +1,599 @@
+openapi: 3.0.3
+info:
+  title: Hibernate Query API
+  description: |
+    Hibernate ORM Query APIs for HQL, Criteria Builder, and Native SQL queries.
+    
+    This documentation represents the Java Query APIs as OpenAPI specifications 
+    for comprehensive documentation. Covers HQL queries, Criteria API, Native SQL, 
+    and query execution methods.
+    
+    **Note**: These are Java method APIs, not actual REST endpoints.
+  version: "7.0.0"
+  contact:
+    name: Hibernate Team
+    url: https://hibernate.org
+  license:
+    name: Apache-2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+
+servers:
+  - url: https://api.hibernate.orm/v7
+    description: Hibernate ORM Query API (conceptual)
+
+tags:
+  - name: HQL Queries
+    description: Hibernate Query Language operations
+  - name: Criteria Queries
+    description: Type-safe Criteria API operations
+  - name: Native Queries
+    description: Native SQL query operations
+  - name: Query Execution
+    description: Query execution and result handling
+  - name: Query Parameters
+    description: Parameter binding operations
+
+paths:
+  /session/{sessionId}/query/hql:
+    post:
+      tags: [HQL Queries]
+      summary: Create HQL query
+      description: Create a Query instance from HQL string
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HQLQueryRequest'
+      responses:
+        '201':
+          description: HQL query created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Query'
+        '400':
+          description: Invalid HQL syntax
+
+  /session/{sessionId}/query/criteria:
+    post:
+      tags: [Criteria Queries]
+      summary: Create criteria query
+      description: Create a Query instance from Criteria object
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CriteriaQueryRequest'
+      responses:
+        '201':
+          description: Criteria query created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Query'
+
+  /session/{sessionId}/query/native:
+    post:
+      tags: [Native Queries]
+      summary: Create native SQL query
+      description: Create a NativeQuery instance from SQL string
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NativeQueryRequest'
+      responses:
+        '201':
+          description: Native query created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NativeQuery'
+        '400':
+          description: Invalid SQL syntax
+
+  /session/{sessionId}/query/named/{queryName}:
+    get:
+      tags: [HQL Queries]
+      summary: Get named query
+      description: Retrieve a named query by name
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: queryName
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: resultClass
+          in: query
+          schema:
+            type: string
+          description: Expected result type class name
+      responses:
+        '200':
+          description: Named query retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Query'
+        '404':
+          description: Named query not found
+
+  /query/{queryId}/parameters/{parameterName}:
+    put:
+      tags: [Query Parameters]
+      summary: Set named parameter
+      description: Bind a value to a named parameter
+      parameters:
+        - name: queryId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: parameterName
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ParameterValue'
+      responses:
+        '200':
+          description: Parameter set successfully
+        '400':
+          description: Invalid parameter name or value
+
+  /query/{queryId}/parameters/{position}:
+    put:
+      tags: [Query Parameters]
+      summary: Set positional parameter
+      description: Bind a value to a positional parameter
+      parameters:
+        - name: queryId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: position
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ParameterValue'
+      responses:
+        '200':
+          description: Parameter set successfully
+        '400':
+          description: Invalid parameter position or value
+
+  /query/{queryId}/execute/list:
+    get:
+      tags: [Query Execution]
+      summary: Execute query and get list
+      description: Execute the query and return results as a list
+      parameters:
+        - name: queryId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: maxResults
+          in: query
+          schema:
+            type: integer
+          description: Maximum number of results to return
+        - name: firstResult
+          in: query
+          schema:
+            type: integer
+          description: Position of first result to retrieve
+      responses:
+        '200':
+          description: Query executed successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueryResultList'
+        '400':
+          description: Query execution failed
+
+  /query/{queryId}/execute/single:
+    get:
+      tags: [Query Execution]
+      summary: Execute query and get single result
+      description: Execute the query and return a single result
+      parameters:
+        - name: queryId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Single result returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueryResult'
+        '404':
+          description: No result found
+        '409':
+          description: Multiple results found (NonUniqueResultException)
+
+  /query/{queryId}/execute/unique:
+    get:
+      tags: [Query Execution]
+      summary: Execute query and get unique result
+      description: Execute the query expecting exactly one result or null
+      parameters:
+        - name: queryId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Unique result returned (may be null)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueryResult'
+        '409':
+          description: Multiple results found
+
+  /query/{queryId}/execute/stream:
+    get:
+      tags: [Query Execution]
+      summary: Execute query as stream
+      description: Execute the query and return results as a stream
+      parameters:
+        - name: queryId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Query stream created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueryStream'
+
+  /query/{queryId}/execute/update:
+    post:
+      tags: [Query Execution]
+      summary: Execute update/delete query
+      description: Execute a bulk update or delete query
+      parameters:
+        - name: queryId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Update executed successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateResult'
+
+  /query/{queryId}/scroll:
+    get:
+      tags: [Query Execution]
+      summary: Execute query with scrollable results
+      description: Execute the query and return scrollable results
+      parameters:
+        - name: queryId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: scrollMode
+          in: query
+          schema:
+            $ref: '#/components/schemas/ScrollMode'
+      responses:
+        '200':
+          description: Scrollable results created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScrollableResults'
+
+  /query/{queryId}/configuration:
+    put:
+      tags: [Query Execution]
+      summary: Configure query options
+      description: Set various query execution options
+      parameters:
+        - name: queryId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QueryConfiguration'
+      responses:
+        '200':
+          description: Query configured successfully
+
+components:
+  schemas:
+    HQLQueryRequest:
+      type: object
+      required:
+        - hql
+      properties:
+        hql:
+          type: string
+          description: HQL query string
+          example: "SELECT p FROM Person p WHERE p.age > :minAge"
+        resultClass:
+          type: string
+          description: Expected result type class name
+          example: "com.example.Person"
+
+    CriteriaQueryRequest:
+      type: object
+      required:
+        - criteriaDefinition
+      properties:
+        criteriaDefinition:
+          type: object
+          description: Serialized criteria query definition
+        resultClass:
+          type: string
+          description: Expected result type class name
+
+    NativeQueryRequest:
+      type: object
+      required:
+        - sql
+      properties:
+        sql:
+          type: string
+          description: Native SQL query string
+          example: "SELECT * FROM persons WHERE age > ?"
+        resultClass:
+          type: string
+          description: Expected result type class name
+        resultSetMapping:
+          type: string
+          description: Name of the result set mapping
+
+    Query:
+      type: object
+      properties:
+        queryId:
+          type: string
+        queryString:
+          type: string
+        resultType:
+          type: string
+        parameters:
+          type: array
+          items:
+            $ref: '#/components/schemas/QueryParameter'
+        maxResults:
+          type: integer
+        firstResult:
+          type: integer
+        timeout:
+          type: integer
+        fetchSize:
+          type: integer
+        flushMode:
+          $ref: '#/components/schemas/FlushModeType'
+        cacheMode:
+          $ref: '#/components/schemas/CacheMode'
+        cacheable:
+          type: boolean
+        cacheRegion:
+          type: string
+        readOnly:
+          type: boolean
+
+    NativeQuery:
+      allOf:
+        - $ref: '#/components/schemas/Query'
+        - type: object
+          properties:
+            addScalar:
+              type: array
+              items:
+                $ref: '#/components/schemas/ScalarReturn'
+            addEntity:
+              type: array
+              items:
+                $ref: '#/components/schemas/EntityReturn'
+
+    QueryParameter:
+      type: object
+      properties:
+        name:
+          type: string
+        position:
+          type: integer
+        type:
+          type: string
+        value:
+          type: object
+
+    ParameterValue:
+      type: object
+      required:
+        - value
+      properties:
+        value:
+          type: object
+          description: Parameter value (can be any type)
+        temporalType:
+          $ref: '#/components/schemas/TemporalType'
+        hibernateType:
+          type: string
+          description: Hibernate type name
+
+    QueryResultList:
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            type: object
+        totalCount:
+          type: integer
+        hasMore:
+          type: boolean
+
+    QueryResult:
+      type: object
+      properties:
+        result:
+          type: object
+          description: Single query result
+
+    QueryStream:
+      type: object
+      properties:
+        streamId:
+          type: string
+        hasNext:
+          type: boolean
+
+    UpdateResult:
+      type: object
+      properties:
+        affectedRows:
+          type: integer
+
+    ScrollableResults:
+      type: object
+      properties:
+        scrollId:
+          type: string
+        current:
+          type: object
+        rowNumber:
+          type: integer
+
+    QueryConfiguration:
+      type: object
+      properties:
+        maxResults:
+          type: integer
+        firstResult:
+          type: integer
+        timeout:
+          type: integer
+        fetchSize:
+          type: integer
+        flushMode:
+          $ref: '#/components/schemas/FlushModeType'
+        cacheMode:
+          $ref: '#/components/schemas/CacheMode'
+        cacheable:
+          type: boolean
+        cacheRegion:
+          type: string
+        readOnly:
+          type: boolean
+        lockMode:
+          $ref: '#/components/schemas/LockModeType'
+
+    ScalarReturn:
+      type: object
+      properties:
+        columnAlias:
+          type: string
+        hibernateType:
+          type: string
+
+    EntityReturn:
+      type: object
+      properties:
+        entityClass:
+          type: string
+        tableAlias:
+          type: string
+
+    ScrollMode:
+      type: string
+      enum:
+        - FORWARD_ONLY
+        - SCROLL_INSENSITIVE
+        - SCROLL_SENSITIVE
+
+    TemporalType:
+      type: string
+      enum:
+        - DATE
+        - TIME
+        - TIMESTAMP
+
+    FlushModeType:
+      type: string
+      enum:
+        - AUTO
+        - COMMIT
+        - MANUAL
+
+    CacheMode:
+      type: string
+      enum:
+        - NORMAL
+        - IGNORE
+        - GET
+        - PUT
+        - REFRESH
+
+    LockModeType:
+      type: string
+      enum:
+        - NONE
+        - READ
+        - WRITE
+        - OPTIMISTIC
+        - OPTIMISTIC_FORCE_INCREMENT
+        - PESSIMISTIC_READ
+        - PESSIMISTIC_WRITE
+        - PESSIMISTIC_FORCE_INCREMENT

--- a/api-docs/hibernate-schema-api.yaml
+++ b/api-docs/hibernate-schema-api.yaml
@@ -1,0 +1,655 @@
+openapi: 3.0.3
+info:
+  title: Hibernate Schema Management API
+  description: |
+    Hibernate ORM Schema Management APIs for DDL generation, validation, and schema evolution.
+    
+    This documentation represents the Java Schema Management APIs as OpenAPI specifications 
+    for comprehensive documentation. Covers database schema creation, validation, 
+    updating, and migration operations.
+    
+    **Note**: These are Java method APIs, not actual REST endpoints.
+  version: "7.0.0"
+  contact:
+    name: Hibernate Team
+    url: https://hibernate.org
+  license:
+    name: Apache-2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+
+servers:
+  - url: https://api.hibernate.orm/v7
+    description: Hibernate ORM Schema API (conceptual)
+
+tags:
+  - name: Schema Manager
+    description: Core schema management operations
+  - name: DDL Generation
+    description: Database schema DDL generation
+  - name: Schema Validation
+    description: Schema validation operations
+  - name: Schema Migration
+    description: Schema migration and evolution
+  - name: Metadata Extraction
+    description: Database metadata extraction
+
+paths:
+  /session-factory/{factoryId}/schema-manager:
+    get:
+      tags: [Schema Manager]
+      summary: Get schema manager
+      description: Retrieve the SchemaManager for the SessionFactory
+      parameters:
+        - name: factoryId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Schema manager retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SchemaManager'
+
+  /schema-manager/{managerId}/create:
+    post:
+      tags: [Schema Manager]
+      summary: Create database schema
+      description: Create the database schema (tables, indexes, constraints)
+      parameters:
+        - name: managerId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SchemaCreateOptions'
+      responses:
+        '200':
+          description: Schema created successfully
+        '400':
+          description: Schema creation failed
+
+  /schema-manager/{managerId}/drop:
+    post:
+      tags: [Schema Manager]
+      summary: Drop database schema
+      description: Drop the database schema (tables, indexes, constraints)
+      parameters:
+        - name: managerId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SchemaDropOptions'
+      responses:
+        '200':
+          description: Schema dropped successfully
+        '400':
+          description: Schema drop failed
+
+  /schema-manager/{managerId}/migrate:
+    post:
+      tags: [Schema Migration]
+      summary: Migrate database schema
+      description: Update existing schema to match current mappings
+      parameters:
+        - name: managerId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SchemaMigrationOptions'
+      responses:
+        '200':
+          description: Schema migrated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MigrationResult'
+        '400':
+          description: Schema migration failed
+
+  /schema-manager/{managerId}/validate:
+    post:
+      tags: [Schema Validation]
+      summary: Validate database schema
+      description: Validate that the database schema matches the mappings
+      parameters:
+        - name: managerId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Schema validation completed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationResult'
+        '400':
+          description: Schema validation failed
+
+  /schema-manager/{managerId}/truncate:
+    post:
+      tags: [Schema Manager]
+      summary: Truncate schema data
+      description: Remove all data from mapped tables
+      parameters:
+        - name: managerId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TruncateOptions'
+      responses:
+        '200':
+          description: Schema data truncated successfully
+
+  /schema-manager/{managerId}/ddl/create:
+    get:
+      tags: [DDL Generation]
+      summary: Generate CREATE DDL
+      description: Generate DDL statements for creating the schema
+      parameters:
+        - name: managerId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: format
+          in: query
+          schema:
+            type: string
+            enum: [SQL, SCRIPT]
+            default: SQL
+      responses:
+        '200':
+          description: CREATE DDL generated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DDLStatements'
+
+  /schema-manager/{managerId}/ddl/drop:
+    get:
+      tags: [DDL Generation]
+      summary: Generate DROP DDL
+      description: Generate DDL statements for dropping the schema
+      parameters:
+        - name: managerId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: format
+          in: query
+          schema:
+            type: string
+            enum: [SQL, SCRIPT]
+            default: SQL
+      responses:
+        '200':
+          description: DROP DDL generated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DDLStatements'
+
+  /schema-manager/{managerId}/ddl/update:
+    get:
+      tags: [DDL Generation]
+      summary: Generate UPDATE DDL
+      description: Generate DDL statements for updating the schema
+      parameters:
+        - name: managerId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: format
+          in: query
+          schema:
+            type: string
+            enum: [SQL, SCRIPT]
+            default: SQL
+      responses:
+        '200':
+          description: UPDATE DDL generated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DDLStatements'
+
+  /schema-manager/{managerId}/metadata/extract:
+    get:
+      tags: [Metadata Extraction]
+      summary: Extract database metadata
+      description: Extract metadata information from the database
+      parameters:
+        - name: managerId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: includeSequences
+          in: query
+          schema:
+            type: boolean
+            default: true
+        - name: includeTables
+          in: query
+          schema:
+            type: boolean
+            default: true
+        - name: includeIndexes
+          in: query
+          schema:
+            type: boolean
+            default: true
+      responses:
+        '200':
+          description: Database metadata extracted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DatabaseMetadata'
+
+  /schema-manager/{managerId}/metadata/tables:
+    get:
+      tags: [Metadata Extraction]
+      summary: Get table metadata
+      description: Extract metadata for all mapped tables
+      parameters:
+        - name: managerId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Table metadata retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TableMetadata'
+
+  /schema-manager/{managerId}/metadata/sequences:
+    get:
+      tags: [Metadata Extraction]
+      summary: Get sequence metadata
+      description: Extract metadata for all sequences
+      parameters:
+        - name: managerId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Sequence metadata retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SequenceMetadata'
+
+components:
+  schemas:
+    SchemaManager:
+      type: object
+      properties:
+        managerId:
+          type: string
+        databaseDialect:
+          type: string
+        supportedActions:
+          type: array
+          items:
+            $ref: '#/components/schemas/SchemaAction'
+
+    SchemaCreateOptions:
+      type: object
+      properties:
+        createTables:
+          type: boolean
+          default: true
+        createSequences:
+          type: boolean
+          default: true
+        createIndexes:
+          type: boolean
+          default: true
+        createConstraints:
+          type: boolean
+          default: true
+        haltOnError:
+          type: boolean
+          default: true
+        scriptTargets:
+          type: array
+          items:
+            type: string
+
+    SchemaDropOptions:
+      type: object
+      properties:
+        dropTables:
+          type: boolean
+          default: true
+        dropSequences:
+          type: boolean
+          default: true
+        dropConstraints:
+          type: boolean
+          default: true
+        haltOnError:
+          type: boolean
+          default: false
+        scriptTargets:
+          type: array
+          items:
+            type: string
+
+    SchemaMigrationOptions:
+      type: object
+      properties:
+        createMissingTables:
+          type: boolean
+          default: true
+        alterExistingTables:
+          type: boolean
+          default: true
+        createMissingColumns:
+          type: boolean
+          default: true
+        dropUnusedColumns:
+          type: boolean
+          default: false
+        createMissingIndexes:
+          type: boolean
+          default: true
+        createMissingConstraints:
+          type: boolean
+          default: true
+        haltOnError:
+          type: boolean
+          default: true
+
+    TruncateOptions:
+      type: object
+      properties:
+        truncateTables:
+          type: array
+          items:
+            type: string
+        cascadeDelete:
+          type: boolean
+          default: false
+        resetSequences:
+          type: boolean
+          default: true
+
+    DDLStatements:
+      type: object
+      properties:
+        statements:
+          type: array
+          items:
+            type: string
+        format:
+          type: string
+          enum: [SQL, SCRIPT]
+        lineCount:
+          type: integer
+
+    ValidationResult:
+      type: object
+      properties:
+        isValid:
+          type: boolean
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationError'
+        warnings:
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationWarning'
+
+    ValidationError:
+      type: object
+      properties:
+        errorType:
+          type: string
+          enum: [MISSING_TABLE, MISSING_COLUMN, TYPE_MISMATCH, MISSING_INDEX, MISSING_CONSTRAINT]
+        tableName:
+          type: string
+        columnName:
+          type: string
+        expectedType:
+          type: string
+        actualType:
+          type: string
+        message:
+          type: string
+
+    ValidationWarning:
+      type: object
+      properties:
+        warningType:
+          type: string
+        tableName:
+          type: string
+        message:
+          type: string
+
+    MigrationResult:
+      type: object
+      properties:
+        success:
+          type: boolean
+        executedStatements:
+          type: array
+          items:
+            type: string
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/MigrationError'
+        tablesCreated:
+          type: integer
+        tablesModified:
+          type: integer
+        indexesCreated:
+          type: integer
+        constraintsCreated:
+          type: integer
+
+    MigrationError:
+      type: object
+      properties:
+        statement:
+          type: string
+        errorMessage:
+          type: string
+        sqlState:
+          type: string
+        errorCode:
+          type: integer
+
+    DatabaseMetadata:
+      type: object
+      properties:
+        databaseProductName:
+          type: string
+        databaseProductVersion:
+          type: string
+        driverName:
+          type: string
+        driverVersion:
+          type: string
+        tables:
+          type: array
+          items:
+            $ref: '#/components/schemas/TableInfo'
+        sequences:
+          type: array
+          items:
+            $ref: '#/components/schemas/SequenceInfo'
+
+    TableMetadata:
+      type: object
+      properties:
+        tables:
+          type: array
+          items:
+            $ref: '#/components/schemas/TableInfo'
+
+    SequenceMetadata:
+      type: object
+      properties:
+        sequences:
+          type: array
+          items:
+            $ref: '#/components/schemas/SequenceInfo'
+
+    TableInfo:
+      type: object
+      properties:
+        tableName:
+          type: string
+        catalogName:
+          type: string
+        schemaName:
+          type: string
+        tableType:
+          type: string
+        columns:
+          type: array
+          items:
+            $ref: '#/components/schemas/ColumnInfo'
+        primaryKey:
+          $ref: '#/components/schemas/PrimaryKeyInfo'
+        foreignKeys:
+          type: array
+          items:
+            $ref: '#/components/schemas/ForeignKeyInfo'
+        indexes:
+          type: array
+          items:
+            $ref: '#/components/schemas/IndexInfo'
+
+    ColumnInfo:
+      type: object
+      properties:
+        columnName:
+          type: string
+        dataType:
+          type: string
+        typeName:
+          type: string
+        columnSize:
+          type: integer
+        decimalDigits:
+          type: integer
+        nullable:
+          type: boolean
+        defaultValue:
+          type: string
+        autoIncrement:
+          type: boolean
+
+    PrimaryKeyInfo:
+      type: object
+      properties:
+        keyName:
+          type: string
+        columns:
+          type: array
+          items:
+            type: string
+
+    ForeignKeyInfo:
+      type: object
+      properties:
+        keyName:
+          type: string
+        columns:
+          type: array
+          items:
+            type: string
+        referencedTableName:
+          type: string
+        referencedColumns:
+          type: array
+          items:
+            type: string
+        updateRule:
+          type: string
+        deleteRule:
+          type: string
+
+    IndexInfo:
+      type: object
+      properties:
+        indexName:
+          type: string
+        unique:
+          type: boolean
+        columns:
+          type: array
+          items:
+            type: string
+        ascending:
+          type: array
+          items:
+            type: boolean
+
+    SequenceInfo:
+      type: object
+      properties:
+        sequenceName:
+          type: string
+        catalogName:
+          type: string
+        schemaName:
+          type: string
+        startValue:
+          type: integer
+        incrementBy:
+          type: integer
+        minValue:
+          type: integer
+        maxValue:
+          type: integer
+        cycle:
+          type: boolean
+
+    SchemaAction:
+      type: string
+      enum:
+        - NONE
+        - CREATE
+        - CREATE_ONLY
+        - CREATE_DROP
+        - DROP
+        - UPDATE
+        - VALIDATE

--- a/api-docs/hibernate-tooling-api.yaml
+++ b/api-docs/hibernate-tooling-api.yaml
@@ -1,0 +1,789 @@
+openapi: 3.0.3
+info:
+  title: Hibernate Tooling API
+  description: |
+    Hibernate ORM Tooling APIs including metamodel generation, build tool plugins, 
+    connection pool integrations, and development tools.
+    
+    This documentation represents the Java Tooling APIs as OpenAPI specifications 
+    for comprehensive documentation. Covers annotation processing, build plugins, 
+    connection pools, and development utilities.
+    
+    **Note**: These are Java method APIs, not actual REST endpoints.
+  version: "7.0.0"
+  contact:
+    name: Hibernate Team
+    url: https://hibernate.org
+  license:
+    name: Apache-2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+
+servers:
+  - url: https://api.hibernate.orm/v7
+    description: Hibernate ORM Tooling API (conceptual)
+
+tags:
+  - name: Metamodel Generator
+    description: Annotation processor for static metamodel generation
+  - name: Build Plugins
+    description: Gradle and Maven plugin operations
+  - name: Connection Pools
+    description: Connection pool management and configuration
+  - name: Development Tools
+    description: Development and debugging utilities
+
+paths:
+  # Metamodel Generator APIs
+  /processor/metamodel/generate:
+    post:
+      tags: [Metamodel Generator]
+      summary: Generate metamodel classes
+      description: Generate static metamodel classes from entity annotations
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MetamodelGenerationRequest'
+      responses:
+        '200':
+          description: Metamodel classes generated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetamodelGenerationResult'
+        '400':
+          description: Generation failed due to invalid annotations
+
+  /processor/metamodel/validate:
+    post:
+      tags: [Metamodel Generator]
+      summary: Validate entity annotations
+      description: Validate entity class annotations for correctness
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AnnotationValidationRequest'
+      responses:
+        '200':
+          description: Validation completed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationResult'
+
+  /processor/repository/generate:
+    post:
+      tags: [Metamodel Generator]
+      summary: Generate repository implementations
+      description: Generate repository implementation classes for Jakarta Data
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RepositoryGenerationRequest'
+      responses:
+        '200':
+          description: Repository implementations generated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RepositoryGenerationResult'
+
+  # Build Plugin APIs
+  /gradle/enhance:
+    post:
+      tags: [Build Plugins]
+      summary: Enhance entity bytecode
+      description: Perform bytecode enhancement on entity classes
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BytecodeEnhancementRequest'
+      responses:
+        '200':
+          description: Bytecode enhancement completed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EnhancementResult'
+
+  /gradle/schema/generate:
+    post:
+      tags: [Build Plugins]
+      summary: Generate schema DDL
+      description: Generate database schema DDL scripts
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SchemaDDLRequest'
+      responses:
+        '200':
+          description: Schema DDL generated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DDLGenerationResult'
+
+  /maven/hbm2ddl:
+    post:
+      tags: [Build Plugins]
+      summary: Execute HBM2DDL
+      description: Execute schema generation or validation via Maven plugin
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HBM2DDLRequest'
+      responses:
+        '200':
+          description: HBM2DDL execution completed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HBM2DDLResult'
+
+  /ant/schemaexport:
+    post:
+      tags: [Build Plugins]
+      summary: Export schema via Ant
+      description: Execute schema export using Ant task
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SchemaExportRequest'
+      responses:
+        '200':
+          description: Schema export completed
+
+  # Connection Pool APIs
+  /connection-pool/hikaricp/configure:
+    post:
+      tags: [Connection Pools]
+      summary: Configure HikariCP
+      description: Configure HikariCP connection pool settings
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HikariCPConfiguration'
+      responses:
+        '200':
+          description: HikariCP configured successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConnectionPoolInfo'
+
+  /connection-pool/c3p0/configure:
+    post:
+      tags: [Connection Pools]
+      summary: Configure C3P0
+      description: Configure C3P0 connection pool settings
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/C3P0Configuration'
+      responses:
+        '200':
+          description: C3P0 configured successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConnectionPoolInfo'
+
+  /connection-pool/agroal/configure:
+    post:
+      tags: [Connection Pools]
+      summary: Configure Agroal
+      description: Configure Agroal connection pool settings
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AgroalConfiguration'
+      responses:
+        '200':
+          description: Agroal configured successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConnectionPoolInfo'
+
+  /connection-pool/{poolId}/statistics:
+    get:
+      tags: [Connection Pools]
+      summary: Get connection pool statistics
+      description: Retrieve connection pool performance statistics
+      parameters:
+        - name: poolId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Connection pool statistics retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConnectionPoolStatistics'
+
+  # Development Tools APIs
+  /dev-tools/sql-logging/enable:
+    post:
+      tags: [Development Tools]
+      summary: Enable SQL logging
+      description: Enable or configure SQL statement logging
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SQLLoggingConfiguration'
+      responses:
+        '200':
+          description: SQL logging configured
+
+  /dev-tools/statistics/enable:
+    post:
+      tags: [Development Tools]
+      summary: Enable statistics collection
+      description: Enable detailed statistics collection for debugging
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StatisticsConfiguration'
+      responses:
+        '200':
+          description: Statistics collection enabled
+
+  /dev-tools/jfr/enable:
+    post:
+      tags: [Development Tools]
+      summary: Enable JFR events
+      description: Enable Java Flight Recorder events for Hibernate operations
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JFRConfiguration'
+      responses:
+        '200':
+          description: JFR events enabled
+
+  /dev-tools/micrometer/configure:
+    post:
+      tags: [Development Tools]
+      summary: Configure Micrometer metrics
+      description: Configure Micrometer metrics collection
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MicrometerConfiguration'
+      responses:
+        '200':
+          description: Micrometer metrics configured
+
+components:
+  schemas:
+    # Metamodel Generator Schemas
+    MetamodelGenerationRequest:
+      type: object
+      required:
+        - entityClasses
+        - outputDirectory
+      properties:
+        entityClasses:
+          type: array
+          items:
+            type: string
+          description: Fully qualified names of entity classes
+        outputDirectory:
+          type: string
+          description: Target directory for generated classes
+        generateJakartaData:
+          type: boolean
+          default: false
+        generateTypeSafeQueries:
+          type: boolean
+          default: true
+        packagePrefix:
+          type: string
+
+    MetamodelGenerationResult:
+      type: object
+      properties:
+        generatedClasses:
+          type: array
+          items:
+            $ref: '#/components/schemas/GeneratedClass'
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProcessingError'
+        processingTime:
+          type: integer
+          description: Processing time in milliseconds
+
+    GeneratedClass:
+      type: object
+      properties:
+        className:
+          type: string
+        filePath:
+          type: string
+        entityClass:
+          type: string
+        attributes:
+          type: array
+          items:
+            $ref: '#/components/schemas/MetamodelAttribute'
+
+    MetamodelAttribute:
+      type: object
+      properties:
+        name:
+          type: string
+        type:
+          type: string
+        attributeType:
+          type: string
+          enum: [SINGULAR, PLURAL, EMBEDDED]
+
+    AnnotationValidationRequest:
+      type: object
+      required:
+        - classesToValidate
+      properties:
+        classesToValidate:
+          type: array
+          items:
+            type: string
+        strictValidation:
+          type: boolean
+          default: false
+
+    RepositoryGenerationRequest:
+      type: object
+      required:
+        - repositoryInterfaces
+        - outputDirectory
+      properties:
+        repositoryInterfaces:
+          type: array
+          items:
+            type: string
+        outputDirectory:
+          type: string
+        implementationSuffix:
+          type: string
+          default: "Impl"
+
+    RepositoryGenerationResult:
+      type: object
+      properties:
+        generatedRepositories:
+          type: array
+          items:
+            $ref: '#/components/schemas/GeneratedRepository'
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProcessingError'
+
+    GeneratedRepository:
+      type: object
+      properties:
+        interfaceName:
+          type: string
+        implementationName:
+          type: string
+        entityType:
+          type: string
+        methods:
+          type: array
+          items:
+            type: string
+
+    ProcessingError:
+      type: object
+      properties:
+        message:
+          type: string
+        className:
+          type: string
+        lineNumber:
+          type: integer
+        kind:
+          type: string
+          enum: [ERROR, WARNING, NOTE]
+
+    ValidationResult:
+      type: object
+      properties:
+        isValid:
+          type: boolean
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProcessingError'
+        warnings:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProcessingError'
+
+    # Build Plugin Schemas
+    BytecodeEnhancementRequest:
+      type: object
+      required:
+        - classesDirectory
+      properties:
+        classesDirectory:
+          type: string
+        enableLazyInitialization:
+          type: boolean
+          default: true
+        enableDirtyTracking:
+          type: boolean
+          default: true
+        enableAssociationManagement:
+          type: boolean
+          default: false
+        enableFieldAccessOptimization:
+          type: boolean
+          default: true
+
+    EnhancementResult:
+      type: object
+      properties:
+        enhancedClasses:
+          type: array
+          items:
+            type: string
+        skippedClasses:
+          type: array
+          items:
+            type: string
+        errors:
+          type: array
+          items:
+            type: string
+
+    SchemaDDLRequest:
+      type: object
+      required:
+        - action
+        - outputFile
+      properties:
+        action:
+          type: string
+          enum: [CREATE, DROP, UPDATE, VALIDATE]
+        outputFile:
+          type: string
+        persistenceUnitName:
+          type: string
+        properties:
+          type: object
+          additionalProperties:
+            type: string
+
+    DDLGenerationResult:
+      type: object
+      properties:
+        outputFile:
+          type: string
+        statementCount:
+          type: integer
+        success:
+          type: boolean
+        errors:
+          type: array
+          items:
+            type: string
+
+    HBM2DDLRequest:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum: [CREATE, DROP, UPDATE, VALIDATE]
+        outputFile:
+          type: string
+        configurationFile:
+          type: string
+        properties:
+          type: object
+          additionalProperties:
+            type: string
+
+    HBM2DDLResult:
+      type: object
+      properties:
+        success:
+          type: boolean
+        executedStatements:
+          type: integer
+        outputFiles:
+          type: array
+          items:
+            type: string
+
+    SchemaExportRequest:
+      type: object
+      required:
+        - configFile
+      properties:
+        configFile:
+          type: string
+        outputFile:
+          type: string
+        drop:
+          type: boolean
+          default: false
+        create:
+          type: boolean
+          default: true
+        quiet:
+          type: boolean
+          default: false
+
+    # Connection Pool Schemas
+    HikariCPConfiguration:
+      type: object
+      required:
+        - jdbcUrl
+      properties:
+        jdbcUrl:
+          type: string
+        username:
+          type: string
+        password:
+          type: string
+        driverClassName:
+          type: string
+        maximumPoolSize:
+          type: integer
+          default: 10
+        minimumIdle:
+          type: integer
+          default: 10
+        connectionTimeout:
+          type: integer
+          default: 30000
+        idleTimeout:
+          type: integer
+          default: 600000
+        maxLifetime:
+          type: integer
+          default: 1800000
+        leakDetectionThreshold:
+          type: integer
+          default: 0
+
+    C3P0Configuration:
+      type: object
+      required:
+        - jdbcUrl
+      properties:
+        jdbcUrl:
+          type: string
+        user:
+          type: string
+        password:
+          type: string
+        driverClass:
+          type: string
+        minPoolSize:
+          type: integer
+          default: 3
+        maxPoolSize:
+          type: integer
+          default: 15
+        initialPoolSize:
+          type: integer
+          default: 3
+        acquireIncrement:
+          type: integer
+          default: 3
+        maxIdleTime:
+          type: integer
+          default: 0
+        testConnectionOnCheckout:
+          type: boolean
+          default: false
+
+    AgroalConfiguration:
+      type: object
+      required:
+        - jdbcUrl
+      properties:
+        jdbcUrl:
+          type: string
+        principal:
+          type: string
+        credential:
+          type: string
+        driverClassName:
+          type: string
+        minSize:
+          type: integer
+          default: 0
+        maxSize:
+          type: integer
+          default: 10
+        initialSize:
+          type: integer
+          default: 0
+        acquisitionTimeout:
+          type: integer
+          default: 5000
+        leakTimeout:
+          type: integer
+          default: 0
+        validationTimeout:
+          type: integer
+          default: 5000
+
+    ConnectionPoolInfo:
+      type: object
+      properties:
+        poolId:
+          type: string
+        poolType:
+          type: string
+          enum: [HIKARICP, C3P0, AGROAL]
+        isConfigured:
+          type: boolean
+        activeConnections:
+          type: integer
+        idleConnections:
+          type: integer
+        totalConnections:
+          type: integer
+
+    ConnectionPoolStatistics:
+      type: object
+      properties:
+        poolId:
+          type: string
+        activeConnections:
+          type: integer
+        idleConnections:
+          type: integer
+        totalConnections:
+          type: integer
+        pendingThreads:
+          type: integer
+        connectionRequests:
+          type: integer
+        connectionAcquisitionTime:
+          type: number
+        connectionUsageTime:
+          type: number
+        leakedConnections:
+          type: integer
+
+    # Development Tools Schemas
+    SQLLoggingConfiguration:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          default: true
+        logLevel:
+          type: string
+          enum: [TRACE, DEBUG, INFO, WARN, ERROR]
+          default: DEBUG
+        logStatements:
+          type: boolean
+          default: true
+        logSlowQueries:
+          type: boolean
+          default: false
+        slowQueryThreshold:
+          type: integer
+          default: 2000
+        formatSql:
+          type: boolean
+          default: true
+        logParameters:
+          type: boolean
+          default: true
+
+    StatisticsConfiguration:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          default: true
+        generateStatistics:
+          type: boolean
+          default: true
+        logSummaryOnSessionClose:
+          type: boolean
+          default: false
+
+    JFRConfiguration:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          default: true
+        recordSessions:
+          type: boolean
+          default: true
+        recordTransactions:
+          type: boolean
+          default: true
+        recordQueries:
+          type: boolean
+          default: true
+        recordCaching:
+          type: boolean
+          default: true
+
+    MicrometerConfiguration:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          default: true
+        meterRegistry:
+          type: string
+        recordSessions:
+          type: boolean
+          default: true
+        recordTransactions:
+          type: boolean
+          default: true
+        recordQueries:
+          type: boolean
+          default: true
+        recordCaching:
+          type: boolean
+          default: true
+        recordConnectionPool:
+          type: boolean
+          default: true

--- a/api-docs/index.yaml
+++ b/api-docs/index.yaml
@@ -1,0 +1,100 @@
+openapi: 3.0.3
+info:
+  title: Hibernate ORM Complete API Index
+  description: |
+    Master index for all Hibernate ORM API documentation.
+    
+    This index provides links to all individual API documentation files
+    for comprehensive coverage of Hibernate ORM functionality.
+    
+    **Note**: These document Java library APIs, not actual REST endpoints.
+  version: "7.0.0"
+  contact:
+    name: Hibernate Team
+    url: https://hibernate.org
+  license:
+    name: Apache-2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+
+servers:
+  - url: https://api.hibernate.orm/v7
+    description: Hibernate ORM API (conceptual)
+
+tags:
+  - name: API Index
+    description: Links to all Hibernate API documentation files
+
+paths:
+  /api-docs:
+    get:
+      tags: [API Index]
+      summary: Get API documentation index
+      description: Retrieve index of all available API documentation
+      responses:
+        '200':
+          description: API documentation index
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIIndex'
+
+components:
+  schemas:
+    APIIndex:
+      type: object
+      properties:
+        hibernateVersion:
+          type: string
+          example: "7.0.0"
+        documentation:
+          type: array
+          items:
+            $ref: '#/components/schemas/APIDocumentation'
+
+    APIDocumentation:
+      type: object
+      properties:
+        name:
+          type: string
+        file:
+          type: string
+        description:
+          type: string
+        categories:
+          type: array
+          items:
+            type: string
+
+  examples:
+    CompleteAPIIndex:
+      value:
+        hibernateVersion: "7.0.0"
+        documentation:
+          - name: "Core Session Management API"
+            file: "hibernate-core-session-api.yaml"
+            description: "SessionFactory, Session, Transaction, and Entity CRUD operations"
+            categories: ["Core", "Session Management", "Transactions", "Entity Operations"]
+          
+          - name: "Query API"
+            file: "hibernate-query-api.yaml"
+            description: "HQL, Criteria, Native SQL queries and execution"
+            categories: ["Queries", "HQL", "Criteria", "SQL", "Parameters"]
+          
+          - name: "Schema Management API"
+            file: "hibernate-schema-api.yaml"
+            description: "Database schema DDL generation, validation, and migration"
+            categories: ["Schema", "DDL", "Migration", "Validation", "Metadata"]
+          
+          - name: "Extended Modules API"
+            file: "hibernate-modules-api.yaml"
+            description: "Envers auditing, Spatial/Vector operations, Caching, Statistics"
+            categories: ["Envers", "Auditing", "Spatial", "Vector", "Caching", "Statistics"]
+          
+          - name: "Tooling API"
+            file: "hibernate-tooling-api.yaml"
+            description: "Metamodel generation, Build plugins, Connection pools, Dev tools"
+            categories: ["Tooling", "Metamodel", "Build Plugins", "Connection Pools", "Development"]
+
+externalDocs:
+  description: Complete API Documentation README
+  url: ./README.md


### PR DESCRIPTION
**WHY:**
To provide a standardized, machine-readable, and easily browsable documentation for all Hibernate ORM APIs, enhancing discoverability and understanding for developers. This documentation treats the Java library APIs as conceptual REST endpoints to leverage OpenAPI tooling.

**WHAT:**
A new `api-docs` directory has been added at the root, containing:
- `index.yaml`: A master index linking all API documentation files.
- `README.md`: A guide explaining the documentation structure and usage.
- Multiple OpenAPI YAML files (`hibernate-core-session-api.yaml`, `hibernate-query-api.yaml`, `hibernate-schema-api.yaml`, `hibernate-modules-api.yaml`, `hibernate-tooling-api.yaml`) detailing the public APIs across various Hibernate modules.
